### PR TITLE
Prepare release v0.1.1

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -11,6 +11,6 @@ jobs:
     name: "pre-commit hooks"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-python@v2
       - uses: pre-commit/action@v3.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
       - id: isort
   # https://github.com/python/black#version-control-integration
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 25.11.0
     hooks:
       - id: black
       - id: black-jupyter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.1.1](https://github.com/mlcast-community/mlcast-dataset-radklim/releases/tag/v0.1.1)
+
+### Fixed
+
+- Rain variable `RR` renamed as `rainfall_amount` to match `standard_name` (`rainfall_amount`) and units (`kg m-2`) present in source netcDF files.
+- Adapt `mlcast` specific meta information to match requirements of `mlcast-dataset-validator@0.1.0`
+
+### Maintenance
+
+- Update `pre-commit` version to ensure compatability with `python3.14` used in github ci
+
 ## [v0.1.0](https://github.com/mlcast-community/mlcast-dataset-radklim/releases/tag/v0.1.0)
 
 First tagged release of zarr version of the RadKlim dataset including both hour

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mlcast-dataset-radklim"
-version = "0.1.0"
+version = "0.1.1"
 description = "Default template for PDM package"
 authors = [
     {name = "Leif Denby", email = "leif@denby.eu"},

--- a/src/mlcast_dataset_radklim/source.py
+++ b/src/mlcast_dataset_radklim/source.py
@@ -15,6 +15,7 @@ hourly acc:      https://opendata.dwd.de/climate_environment/CDC/grids_germany/h
                  https://opendata.dwd.de/climate_environment/CDC/grids_germany/5_minutes/radolan/reproc/2017_002/netCDF/supplement/YW2017.002_2021_netcdf_supplement.tar.gz
 
 """
+
 import tarfile
 from pathlib import Path
 
@@ -120,13 +121,16 @@ class DownloadTask(luigi.Task):
         total_size = int(response.headers.get("content-length", 0))
         output_path = Path(self.output().path)
         output_path.parent.mkdir(parents=True, exist_ok=True)
-        with output_path.open("wb") as out_file, tqdm(
-            desc=f"Downloading {self.year}",
-            total=total_size,
-            unit="B",
-            unit_scale=True,
-            unit_divisor=1024,
-        ) as bar:
+        with (
+            output_path.open("wb") as out_file,
+            tqdm(
+                desc=f"Downloading {self.year}",
+                total=total_size,
+                unit="B",
+                unit_scale=True,
+                unit_divisor=1024,
+            ) as bar,
+        ):
             for chunk in response.iter_content(chunk_size=8192):
                 out_file.write(chunk)
                 bar.update(len(chunk))

--- a/src/mlcast_dataset_radklim/zarr.py
+++ b/src/mlcast_dataset_radklim/zarr.py
@@ -289,7 +289,13 @@ class WriteZarrTask(luigi.Task):
             self.chunking
         )
 
-        # all values for the projection data-array (crs) are the same, we only need to keep one
+        # The variable with the precipitation data is named "RR" in the
+        # original netCDF files, but we want to rename it to "rainfall_amount"
+        # because the units and standard_name suggest a rainfall amount rather than a flux
+        ds = ds.rename({"RR": "rainfall_amount"})
+
+        # all values for the projection data-array (crs) are the same, we only
+        # need to keep one
         ds["crs"] = ds.crs.isel(time=0)
 
         crs_wkt = ds.crs.attrs["crs_wkt"]
@@ -315,14 +321,20 @@ class WriteZarrTask(luigi.Task):
         ds.x.attrs["units"] = "km"
         ds.y.attrs["units"] = "km"
 
-        # add meta info about the zarr dataset creation
-        date = datetime.datetime.now().isoformat()
-        ds.attrs["zarr_creation"] = (
-            "created with mlcast_dataset_radklim "
-            f"(https://github.com/mlcast-community/mlcast-dataset-radklim) on {date} "
-            "by Leif Denby (lcd@dmi.dk)"
+        # add global metadata following the mlcast metadata specification
+        # https://github.com/mlcast-community/mlcast-dataset-validator
+        date = datetime.datetime.now().replace(microsecond=0).isoformat()
+        ds.attrs["mlcast_created_on"] = date
+        ds.attrs["mlcast_created_by"] = "Leif Denby <lcd@dmi.dk>"
+        ds.attrs["mlcast_created_with"] = (
+            "https://github.com/mlcast-community/mlcast-dataset-DE-DWD-radklim"
+            f"@v{__version__}"
         )
-        ds.attrs["zarr_dataset_version"] = __version__
+        ds.attrs["mlcast_dataset_version"] = __version__
+        ds.attrs["mlcast_dataset_identifier"] = "DE-DWD-radar_precipitation-RADKLIM"
+        ds.attrs[
+            "mlcast_dataset_identifier_format"
+        ] = "{country_code}-{entity}-{physical_variable}-{common_name}"
 
         # Write the dataset to Zarr format
         ds.to_zarr(output_path, mode="w", consolidated=True)

--- a/src/mlcast_dataset_radklim/zarr.py
+++ b/src/mlcast_dataset_radklim/zarr.py
@@ -332,9 +332,9 @@ class WriteZarrTask(luigi.Task):
         )
         ds.attrs["mlcast_dataset_version"] = __version__
         ds.attrs["mlcast_dataset_identifier"] = "DE-DWD-radar_precipitation-RADKLIM"
-        ds.attrs[
-            "mlcast_dataset_identifier_format"
-        ] = "{country_code}-{entity}-{physical_variable}-{common_name}"
+        ds.attrs["mlcast_dataset_identifier_format"] = (
+            "{country_code}-{entity}-{physical_variable}-{common_name}"
+        )
 
         # Write the dataset to Zarr format
         ds.to_zarr(output_path, mode="w", consolidated=True)


### PR DESCRIPTION
Fix mlcast meta info and fix var-name

Apply changes to ensure dataset conforms to mlcast-data-validator spec
v0.2.0, and also rename variable from `RR` (as in radklim source netCDF
files) to `rainfall_amount` which matches standard name and units used
in source files.